### PR TITLE
fix: format website url to create a correct link and add target blank [etablissements]

### DIFF
--- a/front/src/components/moderatorEstablishments/establishmentBlock/EstablishmentBlock.test.tsx
+++ b/front/src/components/moderatorEstablishments/establishmentBlock/EstablishmentBlock.test.tsx
@@ -112,6 +112,6 @@ describe('EstablishmentBlock', () => {
     expect(screen.getByText('www.mutuelle-entrenous.fr')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'www.mutuelle-entrenous.fr' })
-    ).toHaveAttribute('href', 'www.mutuelle-entrenous.fr');
+    ).toHaveAttribute('href', '//www.mutuelle-entrenous.fr');
   });
 });

--- a/front/src/components/moderatorEstablishments/establishmentBlock/EstablishmentBlock.tsx
+++ b/front/src/components/moderatorEstablishments/establishmentBlock/EstablishmentBlock.tsx
@@ -6,6 +6,7 @@ import { EstablishmentInformations } from '../establishmentInformations/Estbalis
 import { MODERATOR_ESTABLISHMENTS } from '../../../wording.ts';
 import { Establishment } from '../../../domain/ModeratorEstablishments.ts';
 import { Alert } from '../../common/alert/Alert.tsx';
+import { formatWebsiteUrl } from '@/utils/formatWebsiteUrl.ts';
 import { COMMON } from '../../../wording.ts';
 import './EstablishmentBlock.css';
 
@@ -75,6 +76,8 @@ export const EstablishmentBlock = ({
     fetchEstablishments();
   };
 
+  const formattedUrl = formatWebsiteUrl(establishment.siteWeb || '');
+
   return (
     <div className="fr-container--fluid border-[1px] border-[#e5e5e5]">
       <header className="header p-6 lg:px-10 flex flex-col md:flex-row justify-start items-start md:items-center p-4">
@@ -124,10 +127,11 @@ export const EstablishmentBlock = ({
             )}
             {establishment.siteWeb && (
               <Link
-                href={establishment.siteWeb}
+                href={formattedUrl}
                 label={establishment.siteWeb}
                 icon="cursor-fill"
                 iconPosition="left"
+                target="_blank"
               />
             )}
           </div>

--- a/front/src/utils/formatWebsiteUrl.ts
+++ b/front/src/utils/formatWebsiteUrl.ts
@@ -1,0 +1,13 @@
+export const formatWebsiteUrl = (website: string): string => {
+  if (!website) return '#';
+
+  if (
+    website.startsWith('http://') ||
+    website.startsWith('https://') ||
+    website.startsWith('mailto:')
+  ) {
+    return website;
+  }
+
+  return `//${website}`;
+};

--- a/front/src/utils/tests/formatWebsiteUrl.test.ts
+++ b/front/src/utils/tests/formatWebsiteUrl.test.ts
@@ -1,0 +1,16 @@
+import { formatWebsiteUrl } from '../formatWebsiteUrl.ts';
+
+test('should return an empty link when no website is provided', () => {
+  const website = '';
+  expect(formatWebsiteUrl(website)).toBe('#');
+});
+
+test('should keep the url unchanged when a mailto url is provided', () => {
+  const website = 'mailto:someone@example.com';
+  expect(formatWebsiteUrl(website)).toBe('mailto:someone@example.com');
+});
+
+test('should add "//" for links without "http", "https", or "mailto"', () => {
+  const url = 'www.medium.com';
+  expect(formatWebsiteUrl(url)).toBe('//www.medium.com');
+});


### PR DESCRIPTION
Formate l'url reçue pour en créer un lien correct à utiliser dans les infos d'un établissement [MODERATEUR]